### PR TITLE
Adding in support for private keys for connecting to servers

### DIFF
--- a/lib/meteor-deployment-manager.js
+++ b/lib/meteor-deployment-manager.js
@@ -111,7 +111,8 @@ mdm.processConfig = function (unprocessedConfig, configFilename) {
       if (!value.taskName) { throw { message: "The '" + index + "' environment does not include a task name." }; }
       if (!value.gitBranch) { value.gitBranch = 'master'; }
       if (!value.buildsToKeep) { value.buildsToKeep = 5; }
-      processedConfig.environments[index] = _(value).pick('hostname', 'port', 'username', 'password', 'deploymentDirectory', 'taskName', 'gitBranch');
+      // ADDING IN PRIVATE KEY SUPPORT
+      processedConfig.environments[index] = _(value).pick('hostname', 'port', 'username', 'password', 'privateKey', 'deploymentDirectory', 'taskName', 'gitBranch');
     });
 
     processedConfig.options = _(unprocessedConfig.options).pick('meteorite', 'insecure', 'meteorRelease', 'buildsToKeep');
@@ -218,9 +219,18 @@ mdm.startEngines = function () {
     host: mdm.currentEnvironment.hostname,
     port: mdm.currentEnvironment.port,
     username: mdm.currentEnvironment.username,
-    password: mdm.currentEnvironment.password,
     tryKeyboard: true
   };
+
+  // CHECKING IF WE HAVE A PASSWORD VARIABLE FIRST THEN CHECKING FOR A PRIVATE KEY AND LOAD IT IN
+  if(typeof mdm.currentEnvironment.password !== 'undefined') {
+    mdm.sshConfiguration.password = mdm.currentEnvironment.password;
+  } else if(typeof mdm.currentEnvironment.privateKey !== 'undefined') {
+    console.log ( mdm.currentEnvironment.privateKey );
+    mdm.sshConfiguration.privateKey = require('fs').readFileSync(mdm.currentEnvironment.privateKey);
+  }
+
+  console.log('Current Environment', mdm.currentEnvironment);
 }
 
 mdm.startDeploy = function () {
@@ -411,7 +421,7 @@ mdm.ssh.on('ready', function () {
   if (VERBOSE) { logger.info('Connection ready for input at ' + new Date().toString() + "..."); }
 
   var commands = mdm.commandsToRun;
-
+  
   mdm.runCommandLoop(commands, 0);
 });
 mdm.ssh.on('error', function (error) {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "fs-extra": "",
-    "ssh2": "",
+    "ssh2": ">= 0.2.21",
     "underscore": "",
     "winston": "",
     "colors": ""


### PR DESCRIPTION
Needed support for private keys - which is available in the more recent versions of SSH2 library.  Chooses a password if present, otherwise will look for the private key.
