### PR TITLE
Adding in support for the need to npm install modules

### DIFF
--- a/lib/meteor-deployment-manager.js
+++ b/lib/meteor-deployment-manager.js
@@ -253,7 +253,6 @@ mdm.startDeploy = function () {
   commands.push({ cmd: 'echo "Now extracting bundle.tgz..." && cd working && tar xf bundle.tgz -C ../builds/' + timestamp, output: 'Extracting: ', quiet: false });
   commands.push({ cmd: 'echo "Resetting symbolic link for latest build..." && cd builds && rm -f current && ln -s ' + timestamp + ' current', output: 'Preparing: ', quiet: false });
   // Adding in line for meteor 0.9
-  //var meteor_09_test = new RegExp('^0\.9')
   if (!mdm.processedConfig.options.meteorite && /^0\.9/.test(mdm.processedConfig.options.meteorRelease)) {
     commands.push({ cmd: 'echo "Meteor Package System Enabled - Updating NPM Dependencies..." && cd builds/current/bundle/programs/server && npm install', output: 'Pre-Processing: ', quiet: false });
   }


### PR DESCRIPTION
Meteor 0.9 now requires the npm install command to be run in order to install modules (such as fibers)
